### PR TITLE
test_runnerのArm64 imageビルドに対応

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -17,33 +17,34 @@ jobs:
         context: [test_runner]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ghcr.io/${{ github.repository }}
-        flavor: |
-          prefix=${{ format('{0}-', matrix.context) }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            prefix=${{ format('{0}-', matrix.context) }}
 
-    - name: Set up Buildx
-      uses: docker/setup-buildx-action@v2
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
 
-    - name: Login to ghcr.io
-      uses: docker/login-action@v2
-      if: github.event_name == 'push'
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        if: github.event_name == 'push'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and Push
-      uses: docker/build-push-action@v3
-      with:
-        context: ${{ matrix.context }}
-        push: ${{ github.event_name == 'push' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha,scope=${{ matrix.context }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.context }}
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.context }}
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.context }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -17,34 +17,34 @@ jobs:
         context: [test_runner]
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository }}
-          flavor: |
-            prefix=${{ format('{0}-', matrix.context) }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/${{ github.repository }}
+        flavor: |
+          prefix=${{ format('{0}-', matrix.context) }}
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v2
 
-      - name: Login to ghcr.io
-        uses: docker/login-action@v2
-        if: github.event_name == 'push'
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to ghcr.io
+      uses: docker/login-action@v2
+      if: github.event_name == 'push'
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ matrix.context }}
-          push: ${{ github.event_name == 'push' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.context }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.context }}
-          platforms: linux/amd64,linux/arm64
+    - name: Build and Push
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ matrix.context }}
+        push: ${{ github.event_name == 'push' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=${{ matrix.context }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.context }}
+        platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## 概要
M1 Macだとアーキテクチャの違いでコンパイルが失敗するので、Arm版のImageも作成する。
[参考ドキュメント](https://docs.docker.com/build/ci/github-actions/multi-platform/)