### PR TITLE
web_serverとjudge_serverのDockerコンテナ化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Postgres DB Environment
+POSTGRES_USER=non_manaka
+POSTGRES_PASSWORD=NonSugar
+POSTGRES_DB=hccc_judge
+
+# Postgres DB Dev Environment
+POSTGRES_PORT=5433
+
+# web_server Environment
+BACKEND_PORT=55301
+CONTEST_BEGIN=2022-11-13T19:00:00+09:00
+CONTEST_END=2022-11-13T21:00:00+09:00
+RUST_LOG=web_server=info

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 web_server, judge_server, test_runner, DB の構成です。
 
+以下のコマンドで起動出来ます。
+
+また，`.env.example`の環境変数をセットすることが出来ます。
+
 ```bash
 # /
 docker-compose pull test_runner
@@ -26,5 +30,20 @@ docker-compose up
 - axum
 - Docker
 - postgres
+
+## 開発者向け
+以下のコマンドで開発向け環境を立ち上げることができます。
+
+```bash
+# 開発向け環境(ホットリロード，dbポート解放)
+docker compose -f docker-compose.yaml -f docker-compose.local.yaml up
+```
+
+また、実際に提出物を実行するtest_runnerは、以下のコマンドでコンテナイメージ作成が行えます。
+
+```bash
+# 開発向け環境(ホットリロード，dbポート解放)
+docker compose -f docker-compose.yaml -f docker-compose.local.yaml build test_runner
+```
 
 infrastructure for [HCCC](https://github.com/Alignof/Human_C_Compiler_Contest)

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ web_server, judge_server, test_runner, DB の構成です。
 
 以下のコマンドで起動出来ます。
 
-また，`.env.example`の環境変数をセットすることが出来ます。
-
 ```bash
 # /
-docker-compose pull test_runner
-docker-compose up
+docker compose pull test_runner
+docker compose up
 ```
+
+また、`.env.example`の環境変数をセットすることが出来ます。
 
 ※ 同時にフロントエンド側の起動も必要です。
 
@@ -42,7 +42,6 @@ docker compose -f docker-compose.yaml -f docker-compose.local.yaml up
 また、実際に提出物を実行するtest_runnerは、以下のコマンドでコンテナイメージ作成が行えます。
 
 ```bash
-# 開発向け環境(ホットリロード，dbポート解放)
 docker compose -f docker-compose.yaml -f docker-compose.local.yaml build test_runner
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ web_server, judge_server, test_runner, DB の構成です。
 ```bash
 # /
 docker-compose up
-
-# /web_server
-cargo run
-
-# /judge_server
-cargo run
 ```
 
 ※ 同時にフロントエンド側の起動も必要です。

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ web_server, judge_server, test_runner, DB の構成です。
 
 ```bash
 # /
+docker-compose pull test_runner
 docker-compose up
 ```
 

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -4,6 +4,9 @@ services:
     build:
       context: ./web_server
       dockerfile: Dockerfile.local
+    environment:
+      RUST_LOG: ${RUST_LOG:-web_server=trace}
+      DATABASE_URL: postgres://${POSTGRES_USER:-non_manaka}@db:5432/${POSTGRES_DB:-hccc_judge}
     volumes:
       - ./web_server/Cargo.toml:/app/Cargo.toml
       - ./web_server/Cargo.lock:/app/Cargo.lock
@@ -16,6 +19,8 @@ services:
     build:
       context: ./judge_server
       dockerfile: Dockerfile.local
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-non_manaka}@db:5432/${POSTGRES_DB:-hccc_judge}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./judge_server/Cargo.toml:/app/Cargo.toml
@@ -27,7 +32,9 @@ services:
 
   db:
     ports:
-      - "5433:5432"
+      - ${POSTGRES_PORT:-5433}:5432
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   test_runner:
     build: test_runner

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -29,6 +29,9 @@ services:
     ports:
       - "5433:5432"
 
+  test_runner:
+    build: test_runner
+
 volumes:
   web_server_cargo_registry:
   web_server_target:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+  web_server:
+    build:
+      context: ./web_server
+      dockerfile: Dockerfile.local
+    volumes:
+      - ./web_server/Cargo.toml:/app/Cargo.toml
+      - ./web_server/Cargo.lock:/app/Cargo.lock
+      - ./web_server/src:/app/src
+      - web_server_cargo_registry:/usr/local/cargo/registry
+      - web_server_target:/app/target
+    command: cargo watch -x run
+
+  judge_server:
+    build:
+      context: ./judge_server
+      dockerfile: Dockerfile.local
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./judge_server/Cargo.toml:/app/Cargo.toml
+      - ./judge_server/Cargo.lock:/app/Cargo.lock
+      - ./judge_server/src:/app/src
+      - judge_server_cargo_registry:/usr/local/cargo/registry
+      - judge_server_target:/app/target
+    command: cargo watch -x run
+
+  db:
+    ports:
+      - "5433:5432"
+
+volumes:
+  web_server_cargo_registry:
+  web_server_target:
+  judge_server_cargo_registry:
+  judge_server_target:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -22,7 +22,6 @@ services:
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-non_manaka}@db:5432/${POSTGRES_DB:-hccc_judge}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - ./judge_server/Cargo.toml:/app/Cargo.toml
       - ./judge_server/Cargo.lock:/app/Cargo.lock
       - ./judge_server/src:/app/src

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       DATABASE_URL: "postgres://non_manaka@db:5432/hccc_judge"
       CONTEST_BEGIN: "2022-11-13T18:00:00+09:00"
       CONTEST_END: "2022-11-13T19:00:00+09:00"
+    depends_on:
+      - db
     
   judge_server:
     build: judge_server
@@ -18,6 +20,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       DATABASE_URL: "postgres://non_manaka@db:5432/hccc_judge"
+    depends_on:
+      - db
 
   db:
     image: postgres:14-alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,8 @@ services:
     container_name: test_runner
     tty: true
     stdin_open: true
+    profiles:
+      - test_runner
 
 volumes:
   db_store:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,27 @@
 version: '3'
 services:
+  web_server:
+    build: web_server
+    container_name: web_server
+    ports:
+      - 55301:55301
+    environment:
+      RUST_LOG: "web_server=trace"
+      DATABASE_URL: "postgres://non_manaka@db:5432/hccc_judge"
+      CONTEST_BEGIN: "2022-11-13T18:00:00+09:00"
+      CONTEST_END: "2022-11-13T19:00:00+09:00"
+    
+  judge_server:
+    build: judge_server
+    container_name: judge_server
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      DATABASE_URL: "postgres://non_manaka@db:5432/hccc_judge"
+
   db:
     image: postgres:14-alpine
     container_name: postgres
-    ports:
-      - 5433:5432
     environment:
       POSTGRES_USER: non_manaka
       POSTGRES_DB: hccc_judge
@@ -12,6 +29,7 @@ services:
     volumes:
       - db_store:/var/lib/postgresql/data
       - ./scripts:/docker-entrypoint-initdb.d
+
   test_runner:
     image: ghcr.io/humanccompilercontest/hccc_infra:test_runner-develop
     container_name: test_runner

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,12 +4,12 @@ services:
     build: web_server
     container_name: web_server
     ports:
-      - 55301:55301
+      - ${BACKEND_PORT:-55301}:55301
     environment:
-      RUST_LOG: "web_server=trace"
-      DATABASE_URL: "postgres://non_manaka@db:5432/hccc_judge"
-      CONTEST_BEGIN: "2022-11-13T18:00:00+09:00"
-      CONTEST_END: "2022-11-13T19:00:00+09:00"
+      RUST_LOG: ${RUST_LOG:-web_server=info}
+      DATABASE_URL: postgres://${POSTGRES_USER:-non_manaka}:${POSTGRES_PASSWORD:-NonSugar}@db:5432/${POSTGRES_DB:-hccc_judge}
+      CONTEST_BEGIN: ${CONTEST_BEGIN:-2022-11-13T19:00:00+09:00}
+      CONTEST_END: ${CONTEST_END:-2022-11-13T21:00:00+09:00}
     depends_on:
       - db
     
@@ -19,7 +19,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      DATABASE_URL: "postgres://non_manaka@db:5432/hccc_judge"
+      DATABASE_URL: postgres://${POSTGRES_USER:-non_manaka}:${POSTGRES_PASSWORD:-NonSugar}@db:5432/${POSTGRES_DB:-hccc_judge}
     depends_on:
       - db
 
@@ -27,9 +27,9 @@ services:
     image: postgres:14-alpine
     container_name: postgres
     environment:
-      POSTGRES_USER: non_manaka
-      POSTGRES_DB: hccc_judge
-      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: ${POSTGRES_USER:-non_manaka}
+      POSTGRES_DB: ${POSTGRES_DB:-hccc_judge}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-NonSugar}
     volumes:
       - db_store:/var/lib/postgresql/data
       - ./scripts:/docker-entrypoint-initdb.d

--- a/judge_server/Dockerfile
+++ b/judge_server/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:1.72.1 AS builder
+
+# Build judge_server
+WORKDIR /app
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release && cp target/release/judge_server /app/judge_server
+
+FROM debian:bookworm-slim AS runner
+WORKDIR /app
+
+# Install docker client(for running test_runner)
+RUN apt-get update && apt-get install -y \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV DOCKER_CLIENT_VERSION=24.0.6
+ENV DOCKER_API_VERSION=1.43
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLIENT_VERSION}.tgz \
+  | tar -xzC /usr/local/bin --strip=1 docker/docker
+
+# Copy judge_server
+COPY --from=builder /app/judge_server ./judge_server
+
+CMD ["/app/judge_server"]

--- a/judge_server/Dockerfile.local
+++ b/judge_server/Dockerfile.local
@@ -1,0 +1,23 @@
+FROM rust:1.72.1
+
+# Install cargo-watch
+RUN cargo install cargo-watch
+
+# Install docker client(for running test_runner)
+RUN apt-get update && apt-get install -y \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV DOCKER_CLIENT_VERSION=24.0.6
+ENV DOCKER_API_VERSION=1.43
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLIENT_VERSION}.tgz \
+  | tar -xzC /usr/local/bin --strip=1 docker/docker
+
+# Build judge_server
+WORKDIR /app
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build
+
+CMD ["/app/target/debug/judge_server"]

--- a/judge_server/src/main.rs
+++ b/judge_server/src/main.rs
@@ -27,7 +27,7 @@ async fn judge(
     let result = Command::new("bash")
         .arg("-c")
         .arg(dbg!(format!(
-            "sudo docker run --rm --memory=128M --cpus=\"0.05\" {} {} {} {}",
+            "docker run --rm --memory=128M --cpus=\"0.05\" {} {} {} {}",
             CONTAINER_NAME,
             base64::encode(&submit.asm),
             serde_json::to_string(&problem.test_target).expect("getting renamed name failed"),

--- a/web_server/Dockerfile
+++ b/web_server/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.72.1 AS builder
+
+WORKDIR /app
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release && cp target/release/web_server /app/web_server
+
+FROM debian:bookworm-slim AS runner
+EXPOSE 55301
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+  libssl-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/web_server ./web_server
+
+CMD ["/app/web_server"]

--- a/web_server/Dockerfile.local
+++ b/web_server/Dockerfile.local
@@ -1,0 +1,13 @@
+FROM rust:1.72.1
+EXPOSE 55301
+
+# Install cargo-watch
+RUN cargo install cargo-watch
+
+WORKDIR /app
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build
+
+CMD ["/app/target/debug/web_server"]

--- a/web_server/src/main.rs
+++ b/web_server/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
 
     let app = web_server::app().await;
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 55301));
+    let addr = SocketAddr::from(([0, 0, 0, 0], 55301));
     tracing::info!("listening on {}", addr);
     axum::Server::bind(&addr)
         .serve(app.into_make_service())


### PR DESCRIPTION
## 概要
web_serverとjudge_serverをDockerコンテナ化し，ワンコマンドでインフラが立ち上がるようにした
```bash
# 開発環境向け(ホットリロード，dbポート解放)
docker compose -f docker-compose.yaml -f docker-compose.local.yaml up
# 本番等環境向け
docker compose up
# 従来通りローカルでcargo runするとき(dbのみ立ち上げ)
docker compose -f docker-compose.yaml -f docker-compose.local.yaml up db
```

また，test_runnerをdocker composeコマンドでpull/buildできるようにした
```bash
# pull
docker compose pull test_runner
# ローカルでビルド
docker compose -f docker-compose.yaml -f docker-compose.local.yaml build test_runner
```

## 制約事項
Dockerコンテナ化で以下が従来と変更になっている
- web_server: 待ち受けアドレスをローカルのみから全て受けるように変更
- judge_server: test_runner立ち上げにsudoを使用しないように変更(rootless dockerが動くなら従来のcargoで立ち上げでも使えるはず…)

## 確認事項
- 開発・本番等環境向け両方でログイン・return 42のACができることを確認
- x86_64環境でtest_runnerのビルド，Image名が指定されたものになっていることを確認

## 備考
ホスト側のDockerのソケットが/var/run/docker.sock以外だと上手く動かないと思う